### PR TITLE
Update CORS configuration and relock dependencies

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1090,7 +1090,7 @@
         },
         "nucypher": {
             "git": "https://github.com/nucypher/nucypher.git",
-            "ref": "2403f9f765654ff74327127e7219ecd909a8eeb2"
+            "ref": "6ca074dbe03d77d17ebba7bba251ef1aab9c739a"
         },
         "nucypher-core": {
             "hashes": [
@@ -1565,7 +1565,7 @@
             "hashes": [
                 "sha256:2df1d2b769f0a0177d26231ab8be16e65e3546b17bb0a9a490efd3517c082876"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7' and python_version >= '3.7'",
             "version": "==0.1.3"
         },
         "six": {

--- a/README.rst
+++ b/README.rst
@@ -295,22 +295,6 @@ Docker Compose will be used to start the NGINX reverse proxy and the Porter serv
 
           By default, CORS for the reverse proxy is configured to allow all origins
 
-     If you would like to modify the CORS allowed origin setting to be more specific, you can modify the file to
-     check for specific domains. There are some examples in the file - see `NGINX if-directive <https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#if>`_
-     for adding ore complex conditional checks.
-
-     For example, to only allow requests from all sub-domains of ``example.com``, the file should be edited to include:
-
-     .. code::
-
-        if ($http_origin ~* (.*\.example\.com$)) {
-            set $allow_origin "true";
-        }
-
-     .. note::
-
-         If you modify the file you should rebuild the docker images using docker-compose.
-
 #. *(Optional)* Build the docker images:
 
    .. code:: bash

--- a/deploy/docker/nginx/porter.local_location
+++ b/deploy/docker/nginx/porter.local_location
@@ -5,7 +5,6 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
 #
 if ($request_method ~* "(GET|POST)") {
-
   add_header "Access-Control-Allow-Origin" *;
 }
 

--- a/deploy/docker/nginx/porter.local_location
+++ b/deploy/docker/nginx/porter.local_location
@@ -1,27 +1,20 @@
-set $allow_origin "";
+#
+# Allow CORS for any domain by default - modify if not desired
+#
+# https://enable-cors.org/server_nginx.html
+# https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+#
+if ($request_method ~* "(GET|POST)") {
 
-#
-# Allow CORS for any domain by default - comment out if not desired
-#
-if ($http_origin ~* (.*)) {
-    set $allow_origin "true";
+  add_header "Access-Control-Allow-Origin" *;
 }
 
-#
-# Allow CORS for specific domain. For specifying conditions, see https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#if.
-# Uncomment and edit if desired. There can be one or more of these 'if' directives for various origin checks.
-#
-#if ($http_origin ~* (.*\.yourdomain\.com$)) {
-#    set $allow_origin "true";
-#}
-
-#
-# For multiple top-level domains:
-#
-#if ($http_origin ~* (.*\.yourdomain\.(com|org)$)) {
-#    set $allow_origin "true";
-#}
-
-if ($allow_origin = "true") {
-    add_header 'Access-Control-Allow-Origin' '$http_origin';
+# Preflighted requests
+if ($request_method = 'OPTIONS' ) {
+  add_header "Access-Control-Allow-Origin" *;
+  add_header "Access-Control-Allow-Methods" "GET, POST, OPTIONS, HEAD";
+  # Tell client that this pre-flight info is valid for 20 days
+  add_header 'Access-Control-Max-Age' 1728000;
+  add_header "Access-Control-Allow-Headers" "Authorization, Origin, X-Requested-With, Content-Type, Accept";
+  return 204;
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ eth-utils==2.0.0; python_version >= '3.6' and python_version < '4'
 flask-cors==3.0.10
 flask==2.2.2; python_version >= '3.7'
 frozenlist==1.3.1; python_version >= '3.7'
-git+https://github.com/nucypher/nucypher.git@2403f9f765654ff74327127e7219ecd909a8eeb2#egg=nucypher
+git+https://github.com/nucypher/nucypher.git@6ca074dbe03d77d17ebba7bba251ef1aab9c739a#egg=nucypher
 hendrix==3.4.0
 hexbytes==0.3.0; python_version >= '3.7' and python_version < '4'
 humanize==4.4.0; python_version >= '3.7'
@@ -90,7 +90,7 @@ requests==2.28.1; python_version >= '3.7' and python_version < '4'
 rlp==3.0.0
 semantic-version==2.10.0; python_version >= '2.7'
 service-identity==21.1.0
-simple-rlp==0.1.3; python_version >= '3.7'
+simple-rlp==0.1.3; python_version >= '3.7' and python_version >= '3.7'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 snaptime==0.2.4
 sortedcontainers==2.4.0


### PR DESCRIPTION
Reduce complexity of CORS support - infrastructure providers can update the configuration on their own and don't need hand holding. This version of the configuration file is currently being used `porter-tapir` and `porter-lynx`.

Update `nucypher`/`development` dependency.
