### PR TITLE
Update Porter to use latest `nucypher` changes for dkg-dev-6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,12 +7,12 @@ name = "pypi"
 python_version = "3"
 
 [packages]
-nucypher = {git = "https://github.com/nucypher/nucypher.git", ref = "development"}
+nucypher = {git = "https://github.com/nucypher/nucypher.git", ref = "dkg-dev-6"}
 nucypher-core = ">=0.9.0"  # must be the same as nucypher
 flask-cors = "*"
 
 [dev-packages]
-nucypher = {git = "https://github.com/nucypher/nucypher.git", editable = true, ref = "development", extras = ["dev"]}  # needed for testerchain, and must be editable
+nucypher = {git = "https://github.com/nucypher/nucypher.git", editable = true, ref = "dkg-dev-6", extras = ["dev"]}  # needed for testerchain, and must be editable
 pytest = "<7"  # match with nucypher/nucypher
 pytest-cov = "*"
 pytest-mock = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7af5b35526f0d6c94255b04cafa3f3b70fcee70bad1273ab24a02a03983ef298"
+            "sha256": "7f80e9f10ceac1a0d579f49cea95cd12886855c6c09ef88f8f534be6dd60b430"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1143,7 +1143,7 @@
         },
         "nucypher": {
             "git": "https://github.com/nucypher/nucypher.git",
-            "ref": "0bbd734c64a3c3ab8caca80dbc6be155db93a5e7"
+            "ref": "4862a9a086d8e69f31f3b93f8421e810db5169ef"
         },
         "nucypher-core": {
             "hashes": [
@@ -3558,7 +3558,7 @@
         },
         "nucypher": {
             "git": "https://github.com/nucypher/nucypher.git",
-            "ref": "0bbd734c64a3c3ab8caca80dbc6be155db93a5e7"
+            "ref": "4862a9a086d8e69f31f3b93f8421e810db5169ef"
         },
         "nucypher-core": {
             "hashes": [
@@ -4350,10 +4350,10 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:5be3296fc574fa8a4d9b213b4dcf8c8d0246c08f8bd78315c6286f386c37555a",
-                "sha256:fe85cf5d0b3d0aa3480df689f9f6dc487de783defb0a95043368375dc893645e"
+                "sha256:79afb7c896014038e358401ad1d36889f97a129dfa8031c49b3f238cd1aa3935",
+                "sha256:aa796423eb6a2f4a8cd7a5b02ba6558cb10aab4ccdc0537f63a47b038c520c38"
             ],
-            "version": "==1.25.0"
+            "version": "==1.25.1"
         },
         "service-identity": {
             "hashes": [

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ attrs==23.1.0 ; python_version >= '3.7'
 autobahn==23.1.2 ; python_version >= '3.7'
 automat==22.10.0
 backcall==0.2.0
-backports.zoneinfo==0.2.1 ; python_version >= '3.6'
+backports.zoneinfo==0.2.1 ; python_version >= '3.6' and python_version < '3.9'
 base58==1.0.3
 bitarray==2.7.4
 bytestring-splitter==2.4.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ attrs==23.1.0 ; python_version >= '3.7'
 autobahn==23.1.2 ; python_version >= '3.7'
 automat==22.10.0
 backcall==0.2.0
-backports.zoneinfo==0.2.1 ; python_version >= '3.6' and python_version < '3.9'
+backports.zoneinfo==0.2.1 ; python_version >= '3.6'
 base58==1.0.3
 bitarray==2.7.4
 bytestring-splitter==2.4.1
@@ -86,7 +86,7 @@ msgspec==0.15.1 ; python_version >= '3.8'
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
 nodeenv==1.8.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-nucypher @ git+https://github.com/nucypher/nucypher.git@0bbd734c64a3c3ab8caca80dbc6be155db93a5e7
+nucypher @ git+https://github.com/nucypher/nucypher.git@4862a9a086d8e69f31f3b93f8421e810db5169ef
 nucypher-core==0.9.0
 numpy==1.24.3 ; python_version >= '3.8'
 packaging==23.1 ; python_version >= '3.7'
@@ -143,7 +143,7 @@ rich==12.6.0 ; python_full_version >= '3.6.3' and python_full_version < '4.0.0'
 rlp==3.0.0
 rpds-py==0.7.1 ; python_version >= '3.8'
 semantic-version==2.10.0 ; python_version >= '2.7'
-sentry-sdk==1.25.0
+sentry-sdk==1.25.1
 service-identity==21.1.0
 setuptools==67.8.0 ; python_version >= '3.7'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'

--- a/porter/main.py
+++ b/porter/main.py
@@ -97,6 +97,7 @@ class Porter(Learner):
         if not BlockchainInterfaceFactory.is_interface_initialized(eth_provider_uri=eth_provider_uri):
             BlockchainInterfaceFactory.initialize_interface(eth_provider_uri=eth_provider_uri)
 
+        self.eth_provider_uri = eth_provider_uri
         self.registry = registry or InMemoryContractRegistry.from_latest_publication(network=domain)
         self.application_agent = ContractAgency.get_agent(PREApplicationAgent, registry=self.registry)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ async-timeout==4.0.2 ; python_version >= '3.6'
 attrs==23.1.0 ; python_version >= '3.7'
 autobahn==23.1.2 ; python_version >= '3.7'
 automat==22.10.0
-backports.zoneinfo==0.2.1 ; python_version >= '3.6' and python_version < '3.9'
+backports.zoneinfo==0.2.1 ; python_version >= '3.6'
 bitarray==2.7.4
 bytestring-splitter==2.4.1
 cached-property==1.5.2
@@ -56,7 +56,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
-nucypher @ git+https://github.com/nucypher/nucypher.git@0bbd734c64a3c3ab8caca80dbc6be155db93a5e7
+nucypher @ git+https://github.com/nucypher/nucypher.git@4862a9a086d8e69f31f3b93f8421e810db5169ef
 nucypher-core==0.9.0
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ async-timeout==4.0.2 ; python_version >= '3.6'
 attrs==23.1.0 ; python_version >= '3.7'
 autobahn==23.1.2 ; python_version >= '3.7'
 automat==22.10.0
-backports.zoneinfo==0.2.1 ; python_version >= '3.6'
+backports.zoneinfo==0.2.1 ; python_version >= '3.6' and python_version < '3.9'
 bitarray==2.7.4
 bytestring-splitter==2.4.1
 cached-property==1.5.2


### PR DESCRIPTION
Candidate for Porter `dkg-dev-6`.

Modifications based on latest `nucypher` changes for `dkg-dev-6`:
- `Learner` no longer stores `eth_provider_uri`
- Conditions are now versioned and use prefix notation (does not affect Porter but does affect testing).

