### PR TITLE
Fix `/cbd_decrypt` controller not recognizing `JSONDict` type

### DIFF
--- a/porter/interfaces.py
+++ b/porter/interfaces.py
@@ -82,7 +82,7 @@ class PorterInterface(ControlInterface):
     def cbd_decrypt(
         self,
         threshold: int,
-        encrypted_decryption_requests: Dict[ChecksumAddress, bytes],
+        encrypted_decryption_requests: str,
     ):
         cbd_outcome = self.implementer.cbd_decrypt(
             threshold=threshold,


### PR DESCRIPTION
Steps to reproduce:
- `encrypted_decryption_requests` encoded as `JSONDict` as expected by the `schema.CBDDecrypt`
```
{
    "encrypted_decryption_requests": "{\"0x210eeAC07542F815ebB6FD6689637D8cA2689392\":\"RVRScQACAACTANwAIMzmzOPM/8yGdsz8zJHMzCUtzP/M3MyCbsylE8z1zIzMyMzkOW0XzL9obMz7zP86zOU7PMUFumuuFgfJF5rOtyfHz3pv4A6HbydIvzEWwRP02DI3+3l5ejrQMX0ewxJ+A2kO0bb/GrE88k8pYVIw07guCRv50ukH6oMEmKzWAdPmJb3oYzumutm+6cafSEra+Jk5o3/jfPJvwFLrMSpiSuLUNbSA1lCYNcWj1eBQeLZsKcJaBoCBxqiGlErFNjp9toAx4FUBTdnpNxd+VYoX7F/8M1xyX6jpt4lI3c49tHiL/bmg1xIHx9y5BYgDzbBmjzF+ulHj7sZO+PjF4wksuGm+LGiOgE8a1Ux1cPlOr5in4FotIODzxnwldsF7kP17INNCUNtg8Wsq9y2LoSta/RMyVHHvjBRKwrR6nmh2rrbofHnFVLAo5je/hhLku2XqgJtnw5dpOz2knq1leDeIKzqEGRcX6hGKejjF/7ryAB6RBb/oFdlB90xsqzxD0E1DoUROIfparHRMD00DWxTcOXatRpwd6lCMZV0q2Op2soRFDNCZouRaO6pd/2vrMqp6qehwarJgt7Va+dbvYVfChgwlBAzBzecnmluSaeHvlAY2FAOth57IB3SzgBTb6yzlIEggoFHjrP/5Mxo+9VOhj37CVIhWKZbOgS6tFDJYS27u5qeqX68b3Pzf1AdI7qedsJuk4MisVNXagvA68kecPWuoTLX0vQnqjMvT+6IvEETnCsBZmWnPLPv5Odb2s3a4qQ7NOyiTvuuJ2FdZuK8+Q6kh+LWderzqF4xFDH9HPIBQCQFPGoWxCXc6HiICujluBWh5cPaiPayRm0mRc9CzWTQnx/haeAZ1lXjWP03QjcfaLgXvpAS4Jj2eUcPru6yKt86marNOvTmnaHepk3MieJqSR8fIegNRt7QVob6lA3ogO0WUVu1gnJ1GmFnO9ARHxqv+9irzYpnvwhbcWH8rMZlZkfyOX2mbo9a+2Qk70OswjXGi1HPxCjaPkgAUY8LWLTSaKxoyXnsF4iTfwwxd/t3klTKbhaQ0PFoXSaAguEm1DEC7/kRAUhT4kivFBRuZUh0hbsoR/nRKYiND+ggwjwetJUgNU8wqgLtjbVQ/DUb32iSyS/sqCZOyyXgo1ipKy1KpXYyUbAwRp/7y0M6qtWrAq3+3pDuSXUrTgBu/VCFdFi5T5NhbpgXXPR9PCzab7PYaBv7kM5x1do41uuTNeUbpDwDVhVuOVzL7YJSmOGdCVDluBeAhkmnnIv87fVvDBKAXnEJCDyvxRaxdgsVtiH2gllBhWJaZmv05ptHMHt8bg4PUf1amQL2QyaTSIqASrJ/6VtZQ4wJ7w+LN8yBRogqUtFmVaP4EBRQ3LGnZ2FjZ/WZ0DCLd/Upvo/vVOzczB0z5BZsGhDYB+zUlv154dnqIU2a7xBnGrtBmyEcc9c0Zc0ETtEQ7wmcbFVkqq0PgScWSEGtjC9Jtuxuw9d3csBz6+ZVmoVqKGBh3ETN/rM8APLwaIQU1nvcEIKIKCPZk9QF937CRHuhFxwByk+CRgZkOZG6JzxhmBkZ0ZSR6/zh2yAUYSxxlzTMlCkTuiFZD/EVsIHP4tObXHvC82+grsTDj0POFOudxQA3WspBugvjGH9Vj/oX641O0/bDBoHxJTnU3ZL1dGM9btsIwNwA2EElymxH12eQTjv80qTtre7HdGF6UZsx2tNBGnv9JYGJnNNk+LwtmjuN5UJ1m/D1kMw+eJW3ttxG9xp+N3HfRrWYLqAKIEL9t/j50xCD2TI5QLJFEJCd3AEtP4076FjWoSJ6Lf357Mf+mUo70Hit94E/OTuNtpT89hc8ixSvl57tKnZ+0gdhe1VHi9n/OSRr5oo84Jx9okszd+ox94l1x0XH3k3+2XMYIU5SMNaTiDj7RMHVnANVHCDUpd8DFHqEjT6XRU6RzxymMriZ3qDvs7n/2Dj8pdgw8HDAghPVNBW4/E7t+Gt2D4IVn5J+zygxuVH8ZcFjU0Jz9Gt8V6aoVEtHl\"}",
    "threshold": 1
}
```
- Receiving the following error on `/cbd_decrypt`:

```
{
    "error": "{'encrypted_decryption_requests': ['Not a valid mapping type.']}",
    "version": "1.0.0"
}
```
- Turns out `/cbd_decrypt` expects a `Dict` and not `JSONDict` (which is a `str`)
```
    @attach_schema(schema.CBDDecrypt)
    def cbd_decrypt(
        self,
        threshold: int,
        encrypted_decryption_requests: Dict[ChecksumAddress, bytes],
    ):
```
- Fix attached

Alternatively, we could replace `JSONDict` with `Dict` usage and keep `encrypted_decryption_requests: Dict[ChecksumAddress, bytes]`. What is the reason for using `JSONDict` and not `Dict`?
