### PR TITLE
Porter RC-1 Candidate

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,18 +7,19 @@ name = "pypi"
 python_version = "3"
 
 [packages]
-nucypher = {git = "https://github.com/nucypher/nucypher.git", ref = "dkg-dev-15"}
+nucypher = {git = "https://github.com/nucypher/nucypher.git", ref = "v7.0.0-rc.1"}
 nucypher-core = "==0.12.0"  # must be the same as nucypher
 flask-cors = "*"
 
 [dev-packages]
-nucypher = {git = "https://github.com/nucypher/nucypher.git", editable = true, ref = "dkg-dev-15", extras = ["dev"]}  # needed for testerchain, and must be editable
+nucypher = {git = "https://github.com/nucypher/nucypher.git", editable = true, ref = "v7.0.0-rc.1", extras = ["dev"]}  # needed for testerchain, and must be editable
 pytest = "<7"  # match with nucypher/nucypher
 pytest-cov = "*"
 pytest-mock = "*"
 # Tools
 pre-commit = "2.12.1"
 coverage = "<=6.5.0"
+maya = "*"
 
 
 [pipenv]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e62871d5c144c01492108b21ad223fbb149ac4fc5d7fdfd347375d79896041c8"
+            "sha256": "72b8b70f712c143d3c2033cd48c82283d82abce68b46f63e1225c7ec3dd6099e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1149,7 +1149,7 @@
         },
         "nucypher": {
             "git": "https://github.com/nucypher/nucypher.git",
-            "ref": "ff383dc663c7100cf2ae6f899ed268213b6c653d"
+            "ref": "2b1c7d6df207ecd239db4331f452332dbcd6a8a9"
         },
         "nucypher-core": {
             "hashes": [
@@ -3058,12 +3058,15 @@
         },
         "ijson": {
             "hashes": [
+                "sha256:055b71bbc37af5c3c5861afe789e15211d2d3d06ac51ee5a647adf4def19c0ea",
+                "sha256:0567e8c833825b119e74e10a7c29761dc65fcd155f5d4cb10f9d3b8916ef9912",
                 "sha256:06f9707da06a19b01013f8c65bf67db523662a9b4a4ff027e946e66c261f17f0",
                 "sha256:0974444c1f416e19de1e9f567a4560890095e71e81623c509feff642114c1e53",
                 "sha256:0a4ae076bf97b0430e4e16c9cb635a6b773904aec45ed8dcbc9b17211b8569ba",
                 "sha256:0b9d1141cfd1e6d6643aa0b4876730d0d28371815ce846d2e4e84a2d4f471cf3",
                 "sha256:0e0243d166d11a2a47c17c7e885debf3b19ed136be2af1f5d1c34212850236ac",
                 "sha256:10294e9bf89cb713da05bc4790bdff616610432db561964827074898e174f917",
+                "sha256:105c314fd624e81ed20f925271ec506523b8dd236589ab6c0208b8707d652a0e",
                 "sha256:1844c5b57da21466f255a0aeddf89049e730d7f3dfc4d750f0e65c36e6a61a7c",
                 "sha256:211124cff9d9d139dd0dfced356f1472860352c055d2481459038b8205d7d742",
                 "sha256:2a80c0bb1053055d1599e44dc1396f713e8b3407000e6390add72d49633ff3bb",
@@ -3077,6 +3080,7 @@
                 "sha256:3dcc33ee56f92a77f48776014ddb47af67c33dda361e84371153c4f1ed4434e1",
                 "sha256:4252e48c95cd8ceefc2caade310559ab61c37d82dfa045928ed05328eb5b5f65",
                 "sha256:455d7d3b7a6aacfb8ab1ebcaf697eedf5be66e044eac32508fccdc633d995f0e",
+                "sha256:457f8a5fc559478ac6b06b6d37ebacb4811f8c5156e997f0d87d708b0d8ab2ae",
                 "sha256:46bafb1b9959872a1f946f8dd9c6f1a30a970fc05b7bfae8579da3f1f988e598",
                 "sha256:4a3a6a2fbbe7550ffe52d151cf76065e6b89cfb3e9d0463e49a7e322a25d0426",
                 "sha256:4b2ec8c2a3f1742cbd5f36b65e192028e541b5fd8c7fd97c1fc0ca6c427c704a",
@@ -3103,19 +3107,25 @@
                 "sha256:92dc4d48e9f6a271292d6079e9fcdce33c83d1acf11e6e12696fb05c5889fe74",
                 "sha256:96190d59f015b5a2af388a98446e411f58ecc6a93934e036daa75f75d02386a0",
                 "sha256:9680e37a10fedb3eab24a4a7e749d8a73f26f1a4c901430e7aa81b5da15f7307",
+                "sha256:9788f0c915351f41f0e69ec2618b81ebfcf9f13d9d67c6d404c7f5afda3e4afb",
                 "sha256:98c6799925a5d1988da4cd68879b8eeab52c6e029acc45e03abb7921a4715c4b",
                 "sha256:9c2a12dcdb6fa28f333bf10b3a0f80ec70bc45280d8435be7e19696fab2bc706",
                 "sha256:9e0a27db6454edd6013d40a956d008361aac5bff375a9c04ab11fc8c214250b5",
+                "sha256:a2973ce57afb142d96f35a14e9cfec08308ef178a2c76b8b5e1e98f3960438bf",
                 "sha256:a4d7fe3629de3ecb088bff6dfe25f77be3e8261ed53d5e244717e266f8544305",
                 "sha256:a729b0c8fb935481afe3cf7e0dadd0da3a69cc7f145dbab8502e2f1e01d85a7c",
                 "sha256:ab4db9fee0138b60e31b3c02fff8a4c28d7b152040553b6a91b60354aebd4b02",
+                "sha256:ac44781de5e901ce8339352bb5594fcb3b94ced315a34dbe840b4cff3450e23b",
                 "sha256:b49fd5fe1cd9c1c8caf6c59f82b08117dd6bea2ec45b641594e25948f48f4169",
                 "sha256:b4eb2304573c9fdf448d3fa4a4fdcb727b93002b5c5c56c14a5ffbbc39f64ae4",
                 "sha256:ba33c764afa9ecef62801ba7ac0319268a7526f50f7601370d9f8f04e77fc02b",
                 "sha256:bcc51c84bb220ac330122468fe526a7777faa6464e3b04c15b476761beea424f",
+                "sha256:bdd0dc5da4f9dc6d12ab6e8e0c57d8b41d3c8f9ceed31a99dae7b2baf9ea769a",
                 "sha256:be8495f7c13fa1f622a2c6b64e79ac63965b89caf664cc4e701c335c652d15f2",
+                "sha256:c075a547de32f265a5dd139ab2035900fef6653951628862e5cdce0d101af557",
                 "sha256:c1a4b8eb69b6d7b4e94170aa991efad75ba156b05f0de2a6cd84f991def12ff9",
                 "sha256:c63f3d57dbbac56cead05b12b81e8e1e259f14ce7f233a8cbe7fa0996733b628",
+                "sha256:c6beb80df19713e39e68dc5c337b5c76d36ccf69c30b79034634e5e4c14d6904",
                 "sha256:ccd6be56335cbb845f3d3021b1766299c056c70c4c9165fb2fbe2d62258bae3f",
                 "sha256:cfced0a6ec85916eb8c8e22415b7267ae118eaff2a860c42d2cc1261711d0d31",
                 "sha256:d052417fd7ce2221114f8d3b58f05a83c1a2b6b99cafe0b86ac9ed5e2fc889df",
@@ -3133,6 +3143,7 @@
                 "sha256:f05ed49f434ce396ddcf99e9fd98245328e99f991283850c309f5e3182211a79",
                 "sha256:f4bc87e69d1997c6a55fff5ee2af878720801ff6ab1fb3b7f94adda050651e37",
                 "sha256:f8d54b624629f9903005c58d9321a036c72f5c212701bbb93d1a520ecd15e370",
+                "sha256:fa234ab7a6a33ed51494d9d2197fb96296f9217ecae57f5551a55589091e7853",
                 "sha256:fa8b98be298efbb2588f883f9953113d8a0023ab39abe77fe734b71b46b1220a",
                 "sha256:fbac4e9609a1086bbad075beb2ceec486a3b138604e12d2059a33ce2cba93051",
                 "sha256:fd12e42b9cb9c0166559a3ffa276b4f9fc9d5b4c304e5a13668642d34b48b634"
@@ -3627,7 +3638,7 @@
         },
         "nucypher": {
             "git": "https://github.com/nucypher/nucypher.git",
-            "ref": "ff383dc663c7100cf2ae6f899ed268213b6c653d"
+            "ref": "2b1c7d6df207ecd239db4331f452332dbcd6a8a9"
         },
         "nucypher-core": {
             "hashes": [
@@ -4510,10 +4521,10 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:64a7141005fb775b9db298a30de93e3b83e0ddd1232dc6f36eb38aebc1553291",
-                "sha256:6de2e88304873484207fed836388e422aeff000609b104c802749fd89d56ba5b"
+                "sha256:935e8fbd7787a3702457393b74b13d89a5afb67185bc0af85c00cb27cbd42e7c",
+                "sha256:eeb0b3550536f3bbc05bb1c7e0feb3a78d74acb43b607159a606ed2ec0a33a4d"
             ],
-            "version": "==1.31.0"
+            "version": "==1.32.0"
         },
         "service-identity": {
             "hashes": [

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -85,7 +85,7 @@ msgspec==0.18.2 ; python_version >= '3.8'
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==1.0.0 ; python_version >= '3.5'
 nodeenv==1.8.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-git+https://github.com/nucypher/nucypher.git@ff383dc663c7100cf2ae6f899ed268213b6c653d#egg=nucypher
+git+https://github.com/nucypher/nucypher.git@2b1c7d6df207ecd239db4331f452332dbcd6a8a9#egg=nucypher
 nucypher-core==0.12.0
 numpy==1.24.4 ; python_version >= '3.8'
 packaging==23.1 ; python_version >= '3.7'
@@ -143,7 +143,7 @@ rich==12.6.0 ; python_full_version >= '3.6.3' and python_full_version < '4.0.0'
 rlp==3.0.0
 rpds-py==0.10.0 ; python_version >= '3.8'
 semantic-version==2.10.0 ; python_version >= '2.7'
-sentry-sdk==1.31.0
+sentry-sdk==1.32.0
 service-identity==23.1.0 ; python_version >= '3.8'
 setuptools==68.1.2 ; python_version >= '3.8'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==1.0.0 ; python_version >= '3.5'
-git+https://github.com/nucypher/nucypher.git@ff383dc663c7100cf2ae6f899ed268213b6c653d#egg=nucypher
+git+https://github.com/nucypher/nucypher.git@2b1c7d6df207ecd239db4331f452332dbcd6a8a9#egg=nucypher
 nucypher-core==0.12.0
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 from typing import Iterable, List, Optional, Tuple
 from unittest.mock import MagicMock
 
+import maya
 import pytest
 from click.testing import CliRunner
 from eth_typing import ChecksumAddress
@@ -312,13 +313,14 @@ def dkg_setup(
         )
         ursula.dkg_storage.store_public_key(ritual_id=ritual_id, public_key=public_key)
 
+    now = maya.now()
     ritual = CoordinatorAgent.Ritual(
         initiator=get_random_checksum_address(),
         authority=get_random_checksum_address(),
         access_controller=get_random_checksum_address(),
         dkg_size=num_shares,
-        init_timestamp=123456,
-        end_timestamp=1234567,
+        init_timestamp=now.epoch,
+        end_timestamp=now.add(days=1).epoch,
         threshold=threshold,
         total_transcripts=num_shares,
         total_aggregations=num_shares,


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
- Relock Porter dependencies to `nucypher` `v7.0.0-rc.1` - https://github.com/nucypher/nucypher/tree/v7.0.0-rc.1
- Fix failing test now that ritual endTimestamp values are actually checked.

Tested running local porter on `tapir` and works.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR addresses a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
