### PR TITLE
Fail fast when there are insufficient nodes to sample from based on `quantity` value

### DIFF
--- a/porter/main.py
+++ b/porter/main.py
@@ -130,6 +130,12 @@ class Porter(Learner):
                     exclude_ursulas: Optional[Sequence[ChecksumAddress]] = None,
                     include_ursulas: Optional[Sequence[ChecksumAddress]] = None) -> List[UrsulaInfo]:
         reservoir = self._make_reservoir(exclude_ursulas, include_ursulas)
+        available_nodes_to_sample = len(reservoir.values) + len(reservoir.reservoir)
+        if available_nodes_to_sample < quantity:
+            raise ValueError(
+                f"Insufficient nodes ({available_nodes_to_sample}) from which to sample {quantity}"
+            )
+
         value_factory = PrefetchStrategy(reservoir, quantity)
 
         def get_ursula_info(ursula_address) -> Porter.UrsulaInfo:

--- a/tests/test_get_ursulas.py
+++ b/tests/test_get_ursulas.py
@@ -203,6 +203,10 @@ def test_get_ursulas_python_interface(porter, ursulas):
     for address in exclude_ursulas:
         assert address not in returned_ursula_addresses
 
+    # too many ursulas requested
+    with pytest.raises(ValueError, match="Insufficient nodes"):
+        porter.get_ursulas(quantity=len(ursulas) + 1)
+
 
 def test_get_ursulas_web_interface(porter_web_controller, ursulas):
     # Send bad data to assert error return
@@ -268,11 +272,12 @@ def test_get_ursulas_web_interface(porter_web_controller, ursulas):
         assert address not in returned_ursula_addresses
 
     #
-    # Failure case
+    # Failure case: too many ursulas requested
     #
     failed_ursula_params = dict(get_ursulas_params)
     failed_ursula_params["quantity"] = len(ursulas_list) + 1  # too many to get
     response = porter_web_controller.get(
         "/get_ursulas", data=json.dumps(failed_ursula_params)
     )
-    assert response.status_code == 500
+    assert response.status_code == 400
+    assert "Insufficient nodes" in response.text


### PR DESCRIPTION
…odes from.

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Check whether the reservoir of potential nodes for sampling, is sufficient based on `quantity` to sample requested.

**Issues fixed/closed:**
> - Fixes #...

Fixes #50 .

Related to but still independent from https://github.com/nucypher/nucypher/pull/3333 (set for merge into v7.1.0) other than it being easier to get the reservoir length. If enough people feel like PR 3333 should go into v7.0.0 I can change its base branch. Trying to be cautious with v7.0.0.

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR addresses a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
