### PR TITLE
Relock dependencies for latest `nucypher` `v7.1.x` branch commit - c0a59d48

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1190,7 +1190,7 @@
         },
         "nucypher": {
             "git": "https://github.com/nucypher/nucypher.git",
-            "ref": "bd68f5c6b545cbacc6afed326509fcc5385ea133"
+            "ref": "c0a59d48d7412697b75ce3ddf20b66f44e0caa93"
         },
         "nucypher-core": {
             "hashes": [
@@ -3767,7 +3767,7 @@
         },
         "nucypher": {
             "git": "https://github.com/nucypher/nucypher.git",
-            "ref": "bd68f5c6b545cbacc6afed326509fcc5385ea133"
+            "ref": "c0a59d48d7412697b75ce3ddf20b66f44e0caa93"
         },
         "nucypher-core": {
             "hashes": [
@@ -4735,10 +4735,10 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:320a55cdf9da9097a0bead239c35b7e61f53660ef9878861824fd6d9b2eaf3b5",
-                "sha256:81b5b9ffdd1a374e9eb0c053b5d2012155db9cbe76393a8585677b753bd5fdc1"
+                "sha256:24c83b0b41c887d33328a9166f5950dc37ad58f01c9f2fbff6b87a6f1094170c",
+                "sha256:acaf597b30258fc7663063b291aa99e58f3096e91fe1e6634f4b79f9c1943e8e"
             ],
-            "version": "==1.39.1"
+            "version": "==1.39.2"
         },
         "service-identity": {
             "hashes": [

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -81,7 +81,7 @@ msgspec==0.18.5 ; python_version >= '3.8'
 multidict==6.0.4 ; python_version >= '3.7'
 mypy-extensions==1.0.0 ; python_version >= '3.5'
 nodeenv==1.8.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-git+https://github.com/nucypher/nucypher.git@bd68f5c6b545cbacc6afed326509fcc5385ea133#egg=nucypher
+git+https://github.com/nucypher/nucypher.git@c0a59d48d7412697b75ce3ddf20b66f44e0caa93#egg=nucypher
 nucypher-core==0.13.0
 numpy==1.26.2 ; python_version >= '3.9'
 packaging==23.2 ; python_version >= '3.7'
@@ -138,7 +138,7 @@ rlp==3.0.0
 rpds-py==0.15.2 ; python_version >= '3.8'
 safe-pysha3==1.0.4
 semantic-version==2.10.0 ; python_version >= '2.7'
-sentry-sdk==1.39.1
+sentry-sdk==1.39.2
 service-identity==23.1.0 ; python_version >= '3.8'
 setuptools==69.0.2 ; python_version >= '3.8'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ mnemonic==0.20 ; python_version >= '3.5'
 msgpack==1.0.7 ; python_version >= '3.8'
 msgpack-python==0.5.6
 multidict==6.0.4 ; python_version >= '3.7'
-git+https://github.com/nucypher/nucypher.git@bd68f5c6b545cbacc6afed326509fcc5385ea133#egg=nucypher
+git+https://github.com/nucypher/nucypher.git@c0a59d48d7412697b75ce3ddf20b66f44e0caa93#egg=nucypher
 nucypher-core==0.13.0
 packaging==23.2 ; python_version >= '3.7'
 parsimonious==0.9.0


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**

Related to https://github.com/nucypher/nucypher/pull/3386  which updated the embedded registry for tapir contracts.

This code is currently running on porter-tapir.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR addresses a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
