### PR TITLE
Obfuscate RPC URLs from Porter Logs

### DIFF
--- a/porter/cli/main.py
+++ b/porter/cli/main.py
@@ -1,5 +1,6 @@
 import click
 from nucypher.blockchain.eth import domains
+from nucypher.blockchain.eth.utils import obfuscate_rpc_url
 from nucypher.characters.lawful import Ursula
 from nucypher.cli.config import group_general_config
 from nucypher.cli.options import (
@@ -107,8 +108,12 @@ def run(
     )
 
     emitter.message(f"TACo Domain: {str(PORTER.domain).capitalize()}", color="green")
-    emitter.message(f"ETH Endpoint URI: {eth_endpoint}", color="green")
-    emitter.message(f"Polygon Endpoint URI: {polygon_endpoint}", color="green")
+    emitter.message(
+        f"ETH Endpoint URI: {obfuscate_rpc_url(eth_endpoint)}", color="green"
+    )
+    emitter.message(
+        f"Polygon Endpoint URI: {obfuscate_rpc_url(polygon_endpoint)}", color="green"
+    )
 
     # firm up falsy status (i.e. change specified empty string to None)
     allow_origins = allow_origins if allow_origins else None


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**

Obfuscates printing of ethereum and polygon endpoints in logs on Porter startup.
```
 ______
(_____ \           _
 _____) )__   ____| |_  ____  ____
|  ____/ _ \ / ___)  _)/ _  )/ ___)
| |   | |_| | |   | |_( (/ /| |
|_|    \___/|_|    \___)____)_|

the gateway for TACo protocol operations

TACo Domain: Lynx
ETH Endpoint URI: https://sepolia.infura.io/v3/1e7***
Polygon Endpoint URI: https://polygon-amoy.infura.io/v3/1e7***
Running Porter Web Controller at http://127.0.0.1:9155
```

Didn't make into 3.10.0 but can make it into some other future release.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR addresses a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
