### PR TITLE
Manage Porter threads and backpressure better

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -89,7 +89,7 @@ msgpack==1.1.2 ; python_version >= "3.11" and python_version < "4" and platform_
 msgspec==0.20.0 ; python_version >= "3.10" and python_version < "3.13" and (implementation_name == "cpython" or implementation_name == "pypy")
 multidict==6.7.0 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nodeenv==1.10.0 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
-nucypher @ git+https://github.com/nucypher/nucypher.git@8537180caa8f67a3b69549d27d9f728ef1b773e9 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
+nucypher @ git+https://github.com/nucypher/nucypher.git@9b9ff1f1f1efcc5fc3b91cd4cfc3b1e4d02448dc ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@40fae3328d4bb98bde3fa87d13d720c1c26a9b67#subdirectory=nucypher-core-python ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-pychalk==2.0.2 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-snaptime==0.2.5 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")

--- a/porter/controllers.py
+++ b/porter/controllers.py
@@ -1,13 +1,14 @@
 import inspect
 import json
 import os
+import threading
 from abc import ABC, abstractmethod
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Optional
 
 import maya
-from flask import Flask, Response
+from flask import Flask, Response, g, jsonify, make_response, request
 from hendrix.deploy.base import HendrixDeploy
 from hendrix.deploy.tls import HendrixDeployTLS
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
@@ -128,11 +129,17 @@ class WebController(InterfaceControlServer):
     """
 
     _DEPLOYER_MAX_THREADPOOL_SIZE = int(
-        os.getenv("PORTER_DEPLOYER_MAX_THREADPOOL_SIZE", default=50)
+        os.getenv("PORTER_DEPLOYER_MAX_THREADPOOL_SIZE", default=20)
     )
     _DEPLOYER_MIN_THREADPOOL_SIZE = int(
         os.getenv("PORTER_DEPLOYER_MIN_THREADPOOL_SIZE", default=10)
     )
+    _DEPLOYER_MAX_IN_FLIGHT_REQUESTS = int(
+        os.getenv("PORTER_DEPLOYER_MAX_IN_FLIGHT_REQUESTS", default=15)
+    )
+    _DEPLOYER_IN_FLIGHT_ACQUIRE_TIMEOUT_S = float(
+        os.getenv("PORTER_DEPLOYER_IN_FLIGHT_ACQUIRE_TIMEOUT_S", 3.0)
+    )  # 3s
 
     _emitter_class = WebEmitter
     _crash_on_error_default = False
@@ -141,6 +148,11 @@ class WebController(InterfaceControlServer):
                               400: 'BAD REQUEST',
                               404: 'NOT FOUND',
                               500: 'INTERNAL SERVER ERROR'}
+
+    def __init__(self, in_flight_uncapped_paths=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.in_flight_uncapped_paths = in_flight_uncapped_paths or set()
 
     def test_client(self):
         test_client = self._transport.test_client()
@@ -153,6 +165,40 @@ class WebController(InterfaceControlServer):
     def make_control_transport(self):
         self._transport = Flask(self.app_name)
         self._transport.config["MAX_CONTENT_LENGTH"] = MAX_UPLOAD_CONTENT_LENGTH
+        self._inflight_sem = threading.BoundedSemaphore(
+            self._DEPLOYER_MAX_IN_FLIGHT_REQUESTS
+        )
+
+        @self._transport.before_request
+        def before_request():
+            path = request.path
+
+            # skip acquiring for non-inflight capped path
+            if path in self.in_flight_uncapped_paths:
+                return None
+
+            acquired = self._inflight_sem.acquire(
+                timeout=self._DEPLOYER_IN_FLIGHT_ACQUIRE_TIMEOUT_S
+            )
+            if not acquired:
+                self.log.warn("Too many in-flight requests.")
+                response_data = {
+                    "error": "too_many_requests",
+                    "message": "Too many in-flight requests.",
+                }
+                response = make_response(
+                    jsonify(response_data), 429, {"Retry-After": "3"}
+                )
+                return response
+
+            g._inflight_slot_acquired = True
+            return None
+
+        @self._transport.teardown_request
+        def teardown_request(response):
+            if getattr(g, "_inflight_slot_acquired", False):
+                self._inflight_sem.release()
+            return response
 
         # Return FlaskApp decorator
         return self._transport

--- a/porter/main.py
+++ b/porter/main.py
@@ -99,6 +99,11 @@ class Porter(Learner):
         )
     )
 
+    IN_FLIGHT_UNCAPPED_PATHS = {
+        "/get_ursulas",
+        "/bucket_sampling",
+    }  # these are used for health checks and should not be subject to in-flight request limits
+
     _interface_class = PorterInterface
 
     class UrsulaInfo(NamedTuple):
@@ -560,9 +565,13 @@ class Porter(Learner):
                             crash_on_error: bool = False,
                             htpasswd_filepath: Path = None,
                             cors_allow_origins_list: List[str] = None):
-        controller = WebController(app_name=self.APP_NAME,
-                                   crash_on_error=crash_on_error,
-                                   interface=self._interface_class(porter=self))
+        controller = WebController(
+            in_flight_uncapped_paths=self.IN_FLIGHT_UNCAPPED_PATHS,
+            app_name=self.APP_NAME,
+            crash_on_error=crash_on_error,
+            interface=self._interface_class(porter=self),
+        )
+
         self.controller = controller
 
         # Register Flask Decorator

--- a/porter/main.py
+++ b/porter/main.py
@@ -1,3 +1,4 @@
+import math
 import os
 from collections import defaultdict
 from json import JSONDecodeError
@@ -97,6 +98,10 @@ class Porter(Learner):
             "PORTER_MAX_SIGNING_TIMEOUT",
             default=SigningRequestClient.DEFAULT_TIMEOUT,
         )
+    )
+
+    REQUEST_CLIENT_MAX_WORKER_THREADS = int(
+        os.getenv("PORTER_REQUEST_CLIENT_MAX_WORKER_THREADS", default=10)
     )
 
     IN_FLIGHT_UNCAPPED_PATHS = {
@@ -321,11 +326,15 @@ class Porter(Learner):
         timeout = self._configure_timeout(
             "decryption", timeout, self.MAX_DECRYPTION_TIMEOUT
         )
+        max_worker_threads = min(
+            self.REQUEST_CLIENT_MAX_WORKER_THREADS, math.ceil(threshold * 1.5)
+        )
 
         successes, failures = decryption_client.gather_encrypted_decryption_shares(
             encrypted_requests=encrypted_decryption_requests,
             threshold=threshold,
             timeout=timeout,
+            max_worker_threads=max_worker_threads,
         )
 
         decrypt_outcome = Porter.DecryptOutcome(
@@ -344,10 +353,15 @@ class Porter(Learner):
     ) -> ThresholdSignatureOutcome:
         signature_client = SigningRequestClient(self)
         timeout = self._configure_timeout("signing", timeout, self.MAX_SIGNING_TIMEOUT)
+        max_worker_threads = min(
+            self.REQUEST_CLIENT_MAX_WORKER_THREADS, math.ceil(threshold * 1.5)
+        )
+
         successes, failures = signature_client.gather_signatures(
             encrypted_requests=encrypted_signing_requests,
             threshold=threshold,
             timeout=timeout,
+            max_worker_threads=max_worker_threads,
         )
         signature_outcome = Porter.ThresholdSignatureOutcome(
             encrypted_signature_responses=successes, errors=failures

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ mnemonic==0.21 ; python_version >= "3.10" and python_version < "4" and (implemen
 msgpack-python==0.5.6 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 msgpack==1.1.2 ; python_version >= "3.11" and python_version < "4" and platform_python_implementation == "CPython" and (implementation_name == "cpython" or implementation_name == "pypy")
 multidict==6.7.0 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
-nucypher @ git+https://github.com/nucypher/nucypher.git@8537180caa8f67a3b69549d27d9f728ef1b773e9 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
+nucypher @ git+https://github.com/nucypher/nucypher.git@9b9ff1f1f1efcc5fc3b91cd4cfc3b1e4d02448dc ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@40fae3328d4bb98bde3fa87d13d720c1c26a9b67#subdirectory=nucypher-core-python ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-pychalk==2.0.2 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-snaptime==0.2.5 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")

--- a/tests/taco/test_porter_taco_python_interface.py
+++ b/tests/taco/test_porter_taco_python_interface.py
@@ -194,7 +194,6 @@ def test_taco_decryption_request_ordering(
     value_factory_spy.assert_called_once_with(
         ANY,
         ursulas_to_contact=expected_ursula_request_order,
-        batch_size=ANY,
         threshold=ANY,
     )
 
@@ -448,7 +447,6 @@ def test_taco_sign_request_ordering(
     value_factory_spy.assert_called_once_with(
         ANY,
         ursulas_to_contact=expected_ursula_request_order,
-        batch_size=ANY,
         threshold=ANY,
     )
 

--- a/tests/test_in_flight_request_limiting.py
+++ b/tests/test_in_flight_request_limiting.py
@@ -1,0 +1,190 @@
+"""
+Tests for WebController in-flight request limiting functionality.
+
+This test module validates the semaphore-based request limiting implemented
+in the WebController's before_request and teardown_request hooks.
+"""
+
+import json
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from unittest.mock import MagicMock
+
+import pytest
+
+from porter.controllers import WebController
+from porter.interfaces import PorterInterface
+
+
+@pytest.fixture(scope="function")
+def web_controller():
+    """Create a WebController with uncapped paths."""
+    controller = WebController(
+        interface=MagicMock(spec=PorterInterface),
+        app_name="test-porter",
+        crash_on_error=False,
+        in_flight_uncapped_paths={"/uncapped_endpoint"},
+    )
+    controller.make_control_transport()
+
+    @controller._transport.route("/uncapped_endpoint", methods=["POST"])
+    def uncapped_endpoint():
+        time.sleep(0.05)
+        return json.dumps({"result": "uncapped_success"}), 200
+
+    @controller._transport.route("/capped_endpoint", methods=["POST"])
+    def capped_endpoint():
+        time.sleep(0.05)
+        return json.dumps({"result": "capped_success"}), 200
+
+    yield controller
+
+
+def test_semaphore_acquire_and_release_directly(web_controller):
+    """Test semaphore acquire and release mechanism directly."""
+    web_controller.make_control_transport()
+    try:
+        # Test that we can acquire up to the limit
+        for i in range(web_controller._DEPLOYER_MAX_IN_FLIGHT_REQUESTS):
+            assert web_controller._inflight_sem.acquire(timeout=0.1)
+
+        # This acquire should fail (timeout)
+        assert not web_controller._inflight_sem.acquire(timeout=0.05)
+
+        # Release one slot
+        web_controller._inflight_sem.release()
+
+        # Now we should be able to acquire again
+        assert web_controller._inflight_sem.acquire(timeout=0.1)
+    finally:
+        # Clean up
+        current_value = web_controller._inflight_sem._value
+        web_controller._inflight_sem.release(
+            web_controller._DEPLOYER_MAX_IN_FLIGHT_REQUESTS - current_value
+        )
+
+
+def test_single_request_acquires_and_releases_slot(web_controller):
+    """Test that a single request properly acquires and releases a semaphore slot."""
+    # initial values should be at max
+    assert (
+        web_controller._inflight_sem._value
+        == WebController._DEPLOYER_MAX_IN_FLIGHT_REQUESTS
+    )
+    test_client = web_controller.test_client()
+
+    response = test_client.post("/capped_endpoint")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert data["result"] == "capped_success"
+
+    # after request completes, semaphore should be fully released again
+    assert (
+        web_controller._inflight_sem._value
+        == WebController._DEPLOYER_MAX_IN_FLIGHT_REQUESTS
+    )
+
+
+def test_semaphore_release_on_request_completion(web_controller):
+    """Test that semaphore slots are properly released after request completion."""
+    # Make multiple sequential requests
+    assert (
+        web_controller._inflight_sem._value
+        == WebController._DEPLOYER_MAX_IN_FLIGHT_REQUESTS
+    )
+    test_client = web_controller.test_client()
+
+    for i in range(
+        WebController._DEPLOYER_MAX_IN_FLIGHT_REQUESTS * 2
+    ):  # More than the limit, but sequential
+        response = test_client.post("/capped_endpoint")
+        assert response.status_code == 200, f"Request {i} failed"
+        data = json.loads(response.data)
+        assert data["result"] == "capped_success"
+
+    # After all requests, semaphore should be fully released
+    assert (
+        web_controller._inflight_sem._value
+        == WebController._DEPLOYER_MAX_IN_FLIGHT_REQUESTS
+    )
+
+
+def test_concurrent_requests_within_limit(web_controller):
+    """Test that concurrent requests within the limit all succeed."""
+    # Sequential requests should all work fine
+    assert (
+        web_controller._inflight_sem._value
+        == WebController._DEPLOYER_MAX_IN_FLIGHT_REQUESTS
+    )
+    test_client = web_controller.test_client()
+
+    n_threads = WebController._DEPLOYER_MAX_IN_FLIGHT_REQUESTS
+    futures = []
+    with ThreadPoolExecutor(max_workers=n_threads) as executor:
+        for i in range(n_threads):
+            future = executor.submit(test_client.post, "/capped_endpoint")
+            futures.append(future)
+
+        for future in as_completed(futures):
+            response = future.result()
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            assert data["result"] == "capped_success"
+
+    assert (
+        web_controller._inflight_sem._value
+        == WebController._DEPLOYER_MAX_IN_FLIGHT_REQUESTS
+    )
+
+
+def test_uncapped_path_bypasses_semaphore(web_controller):
+    """Test that uncapped paths don't acquire the semaphore."""
+    test_client = web_controller.test_client()
+    try:
+        # Even if we hold all semaphore slots, uncapped path should work
+        for _ in range(web_controller._DEPLOYER_MAX_IN_FLIGHT_REQUESTS):
+            web_controller._inflight_sem.acquire()
+
+        assert web_controller._inflight_sem._value == 0
+
+        # Make many requests to uncapped endpoint - all should succeed
+        for _ in range(5):
+            response = test_client.post("/uncapped_endpoint")
+            # Semaphore should not be affected
+            assert web_controller._inflight_sem._value == 0
+
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            assert data["result"] == "uncapped_success"
+    finally:
+        # Clean up
+        web_controller._inflight_sem.release(
+            web_controller._DEPLOYER_MAX_IN_FLIGHT_REQUESTS
+        )
+
+
+def test_capped_endpoint_too_many_concurrent_requests_returns_429(web_controller):
+    """Test that exceeding the in-flight limit returns a 429 status code."""
+    test_client = web_controller.test_client()
+    try:
+        # Even if we hold all semaphore slots, uncapped path should work
+        for _ in range(web_controller._DEPLOYER_MAX_IN_FLIGHT_REQUESTS):
+            web_controller._inflight_sem.acquire()
+
+        assert web_controller._inflight_sem._value == 0
+
+        # Make many requests to uncapped endpoint - all should succeed
+        response = test_client.post("/capped_endpoint")
+
+        # Semaphore should not be affected
+        assert web_controller._inflight_sem._value == 0
+
+        assert response.status_code == 429
+        data = json.loads(response.data)
+        assert data["error"] == "too_many_requests"
+        assert data["message"] == "Too many in-flight requests."
+        assert response.headers.get("Retry-After") == "3"
+    finally:
+        # Clean up
+        for _ in range(web_controller._DEPLOYER_MAX_IN_FLIGHT_REQUESTS):
+            web_controller._inflight_sem.release()


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Depends on changes in https://github.com/nucypher/nucypher/pull/3722

- Use a global concurrent requests semaphore for absorbing some back-pressure from too many requests; if the semaphore can't be acquired after a timeout then return 429. Reduce Hendrix max threads since it can overwhelm the server.
   - Add in flight caps for server requests that require communication with multiple nodes in a cohort; we don't limit /get_ursulas and /bucket_sampling since those can be used for health checks.

- Configure max worker threads used per request, and allow overwriting via env variable

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR addresses a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
