### PR TITLE
Porter update based on post-migration deprecation of `duration` when sampling

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -89,7 +89,7 @@ msgpack==1.1.2 ; python_version >= "3.11" and python_version < "4" and platform_
 msgspec==0.20.0 ; python_version >= "3.10" and python_version < "3.13" and (implementation_name == "cpython" or implementation_name == "pypy")
 multidict==6.7.0 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nodeenv==1.10.0 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
-nucypher @ git+https://github.com/nucypher/nucypher.git@b0f610cde06a9dfc79750d85f64bd78c5aa74f2a ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
+nucypher @ git+https://github.com/cygnusv/nucypher.git@361976c2cfef73b62c07fb78d4d915c7e8fef6b9 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@40fae3328d4bb98bde3fa87d13d720c1c26a9b67#subdirectory=nucypher-core-python ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-pychalk==2.0.2 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-snaptime==0.2.5 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -89,7 +89,7 @@ msgpack==1.1.2 ; python_version >= "3.11" and python_version < "4" and platform_
 msgspec==0.20.0 ; python_version >= "3.10" and python_version < "3.13" and (implementation_name == "cpython" or implementation_name == "pypy")
 multidict==6.7.0 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nodeenv==1.10.0 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
-nucypher @ git+https://github.com/cygnusv/nucypher.git@361976c2cfef73b62c07fb78d4d915c7e8fef6b9 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
+nucypher @ git+https://github.com/nucypher/nucypher.git@8537180caa8f67a3b69549d27d9f728ef1b773e9 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@40fae3328d4bb98bde3fa87d13d720c1c26a9b67#subdirectory=nucypher-core-python ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-pychalk==2.0.2 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-snaptime==0.2.5 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")

--- a/porter/interfaces.py
+++ b/porter/interfaces.py
@@ -44,7 +44,6 @@ class PorterInterface(ControlInterface):
         exclude_ursulas: Optional[List[ChecksumAddress]] = None,
         include_ursulas: Optional[List[ChecksumAddress]] = None,
         timeout: Optional[int] = None,
-        duration: Optional[int] = None,
         min_version: Optional[str] = None,
     ) -> Dict:
         ursulas_info = self.implementer.get_ursulas(
@@ -52,7 +51,6 @@ class PorterInterface(ControlInterface):
             exclude_ursulas=exclude_ursulas,
             include_ursulas=include_ursulas,
             timeout=timeout,
-            duration=duration,
             min_version=min_version,
         )
 
@@ -130,7 +128,6 @@ class PorterInterface(ControlInterface):
         random_seed: Optional[int] = None,
         exclude_ursulas: Optional[List[ChecksumAddress]] = None,
         timeout: Optional[int] = None,
-        duration: Optional[int] = None,
         min_version: Optional[str] = None,
     ) -> Dict:
         ursulas, block_number = self.implementer.bucket_sampling(
@@ -138,7 +135,6 @@ class PorterInterface(ControlInterface):
             random_seed=random_seed,
             exclude_ursulas=exclude_ursulas,
             timeout=timeout,
-            duration=duration,
             min_version=min_version,
         )
 

--- a/porter/main.py
+++ b/porter/main.py
@@ -215,7 +215,6 @@ class Porter(Learner):
         exclude_ursulas: Optional[Sequence[ChecksumAddress]] = None,
         include_ursulas: Optional[Sequence[ChecksumAddress]] = None,
         timeout: Optional[int] = None,
-        duration: Optional[int] = None,
         min_version: Optional[str] = None,
     ) -> List[UrsulaInfo]:
         timeout = self._configure_timeout(
@@ -223,10 +222,9 @@ class Porter(Learner):
             timeout or self.DEFAULT_GET_URSULAS_TIMEOUT,
             self.MAX_GET_URSULAS_TIMEOUT,
         )
-        duration = duration or 0
         parse_min_version = parse(min_version) if min_version else None
 
-        reservoir = self._make_reservoir(exclude_ursulas, include_ursulas, duration)
+        reservoir = self._make_reservoir(exclude_ursulas, include_ursulas)
         available_nodes_to_sample = len(reservoir.values) + len(reservoir.reservoir)
         if available_nodes_to_sample < quantity:
             raise ValueError(
@@ -369,13 +367,11 @@ class Porter(Learner):
         self,
         exclude_ursulas: Optional[Sequence[ChecksumAddress]] = None,
         include_ursulas: Optional[Sequence[ChecksumAddress]] = None,
-        duration: Optional[int] = 0,
     ):
         return make_staking_provider_reservoir(
             application_agent=self.taco_child_application_agent,
             exclude_addresses=exclude_ursulas,
             include_addresses=include_ursulas,
-            duration=duration,
         )
 
     def bucket_sampling(
@@ -384,7 +380,6 @@ class Porter(Learner):
         random_seed: Optional[int] = None,
         exclude_ursulas: Optional[Sequence[ChecksumAddress]] = None,
         timeout: Optional[int] = None,
-        duration: Optional[int] = None,
         min_version: Optional[str] = None,
     ) -> Tuple[List[ChecksumAddress], int]:
         timeout = self._configure_timeout(
@@ -392,7 +387,6 @@ class Porter(Learner):
             timeout or self.DEFAULT_BUCKET_SAMPLING_TIMEOUT,
             self.MAX_BUCKET_SAMPLING_TIMEOUT,
         )
-        duration = duration or 0
         parse_min_version = parse(min_version) if min_version else None
 
         if self.domain not in self._ALLOWED_DOMAINS_FOR_BUCKET_SAMPLING:
@@ -429,9 +423,7 @@ class Porter(Learner):
                     return None
 
         block_number = self.taco_child_application_agent.blockchain.client.block_number
-        _, sp_map = self.taco_child_application_agent.get_all_active_staking_providers(
-            duration=duration
-        )
+        _, sp_map = self.taco_child_application_agent.get_all_active_staking_providers()
         for e in exclude_ursulas or []:
             if e in sp_map:
                 del sp_map[e]

--- a/porter/schema.py
+++ b/porter/schema.py
@@ -6,7 +6,6 @@ from porter.cli.types import EIP55_CHECKSUM_ADDRESS
 from porter.fields.base import (
     JSON,
     Integer,
-    NonNegativeInteger,
     PositiveInteger,
     StringList,
     VersionString,
@@ -111,18 +110,6 @@ class GetUrsulas(BaseSchema):
             "--timeout",
             "-t",
             help="Timeout for getting the required quantity of ursulas",
-            type=click.INT,
-            required=False,
-        ),
-    )
-
-    duration = NonNegativeInteger(
-        required=False,
-        load_only=True,
-        click=click.option(
-            "--duration",
-            "-d",
-            help="Minimum duration, in seconds, for which the node should be actively staking",
             type=click.INT,
             required=False,
         ),
@@ -367,18 +354,6 @@ class BucketSampling(BaseSchema):
             "--timeout",
             "-t",
             help="Timeout for getting the required quantity of ursulas",
-            type=click.INT,
-            required=False,
-        ),
-    )
-
-    duration = NonNegativeInteger(
-        required=False,
-        load_only=True,
-        click=click.option(
-            "--duration",
-            "-d",
-            help="Minimum duration, in seconds, for which the node should be actively staking",
             type=click.INT,
             required=False,
         ),

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ mnemonic==0.21 ; python_version >= "3.10" and python_version < "4" and (implemen
 msgpack-python==0.5.6 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 msgpack==1.1.2 ; python_version >= "3.11" and python_version < "4" and platform_python_implementation == "CPython" and (implementation_name == "cpython" or implementation_name == "pypy")
 multidict==6.7.0 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
-nucypher @ git+https://github.com/cygnusv/nucypher.git@361976c2cfef73b62c07fb78d4d915c7e8fef6b9 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
+nucypher @ git+https://github.com/nucypher/nucypher.git@8537180caa8f67a3b69549d27d9f728ef1b773e9 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@40fae3328d4bb98bde3fa87d13d720c1c26a9b67#subdirectory=nucypher-core-python ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-pychalk==2.0.2 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-snaptime==0.2.5 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ mnemonic==0.21 ; python_version >= "3.10" and python_version < "4" and (implemen
 msgpack-python==0.5.6 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 msgpack==1.1.2 ; python_version >= "3.11" and python_version < "4" and platform_python_implementation == "CPython" and (implementation_name == "cpython" or implementation_name == "pypy")
 multidict==6.7.0 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
-nucypher @ git+https://github.com/nucypher/nucypher.git@b0f610cde06a9dfc79750d85f64bd78c5aa74f2a ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
+nucypher @ git+https://github.com/cygnusv/nucypher.git@361976c2cfef73b62c07fb78d4d915c7e8fef6b9 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@40fae3328d4bb98bde3fa87d13d720c1c26a9b67#subdirectory=nucypher-core-python ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-pychalk==2.0.2 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")
 nucypher-snaptime==0.2.5 ; python_version >= "3.10" and python_version < "4" and (implementation_name == "cpython" or implementation_name == "pypy")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,20 +181,13 @@ def signing_coordinator_agent(mock_contract_agency):
     return signing_coordinator_agent
 
 
-@pytest.fixture(scope="module")
-def excluded_staker_address_for_duration_greater_than_0(accounts):
-    yield accounts.staking_provider_account(0)
-
-
 @pytest.fixture(scope="module", autouse=True)
 def mock_sample_reservoir(
     accounts,
     mock_contract_agency,
-    excluded_staker_address_for_duration_greater_than_0,
 ):
     def mock_reservoir(
         without: Optional[Iterable[ChecksumAddress]] = None,
-        duration: int = 0,
         *args,
         **kwargs
     ):
@@ -202,12 +195,7 @@ def mock_sample_reservoir(
         for address in accounts.staking_providers_accounts:
             if address in without:
                 continue
-            if (
-                duration > 0
-                and address == excluded_staker_address_for_duration_greater_than_0
-            ):
-                # skip
-                continue
+
             addresses[address] = 1
         return StakingProvidersReservoir(addresses)
 
@@ -219,17 +207,10 @@ def mock_sample_reservoir(
 def mock_get_all_active_staking_providers(
     accounts,
     mock_contract_agency,
-    excluded_staker_address_for_duration_greater_than_0,
 ):
-    def get_all_active_staking_providers(duration):
+    def get_all_active_staking_providers():
         addresses = dict()
         for address in accounts.staking_providers_accounts:
-            if (
-                duration > 0
-                and address == excluded_staker_address_for_duration_greater_than_0
-            ):
-                # skip
-                continue
             addresses[address] = 1
         return len(addresses), addresses
 

--- a/tests/test_bucket_sampling.py
+++ b/tests/test_bucket_sampling.py
@@ -57,17 +57,6 @@ def test_bucket_sampling_schema(get_random_checksum_address):
 
     # optional components
 
-    # only duration
-    updated_data = dict(required_data)
-    updated_data["duration"] = 0
-    BucketSampling().load(updated_data)
-
-    updated_data["duration"] = 60 * 60 * 24
-    BucketSampling().load(updated_data)
-
-    updated_data["duration"] = 60 * 60 * 365
-    BucketSampling().load(updated_data)
-
     # only exclude
     updated_data = dict(required_data)
     exclude_ursulas = []
@@ -137,17 +126,6 @@ def test_bucket_sampling_schema(get_random_checksum_address):
         updated_data["random_seed"] = "a string"
         BucketSampling().load(updated_data)
 
-    # invalid duration value
-    with pytest.raises(InvalidInputData):
-        updated_data = dict(required_data)
-        updated_data["duration"] = "some number"
-        BucketSampling().load(updated_data)
-
-    with pytest.raises(InvalidInputData):
-        updated_data = dict(required_data)
-        updated_data["duration"] = -1
-        BucketSampling().load(updated_data)
-
     # invalid min version
     with pytest.raises(InvalidInputData):
         updated_data = dict(required_data)
@@ -175,25 +153,13 @@ def test_bucket_sampling_schema(get_random_checksum_address):
     assert output == {"ursulas": expected_ursulas, "block_number": 42}
 
 
-def test_bucket_sampling_python_interface(
-    porter, ursulas, excluded_staker_address_for_duration_greater_than_0
-):
+def test_bucket_sampling_python_interface(porter, ursulas):
     porter._ALLOWED_DOMAINS_FOR_BUCKET_SAMPLING = (TEMPORARY_DOMAIN,)
 
     # simple
     quantity = 4
     sampled_ursulas, _block = porter.bucket_sampling(quantity=quantity)
     assert len(set(sampled_ursulas)) == quantity  # ensure no repeats
-
-    # simple w/ duration
-    quantity = 4
-    sampled_ursulas, _block = porter.bucket_sampling(
-        quantity=quantity, duration=60 * 60 * 24 * 182
-    )
-    assert len(set(sampled_ursulas)) == quantity  # ensure no repeats
-
-    # duration > 0
-    assert excluded_staker_address_for_duration_greater_than_0 not in sampled_ursulas
 
     ursulas_list = list(ursulas)
 
@@ -250,15 +216,12 @@ def test_bucket_sampling_python_interface(
 
 @pytest.mark.parametrize("timeout", [None, 10])
 @pytest.mark.parametrize("random_seed", [None, 42])
-@pytest.mark.parametrize("duration", [None, 0, 60 * 60 * 24, 60 * 60 * 24 * 365])
 def test_bucket_sampling_web_interface(
     porter,
     porter_web_controller,
     ursulas,
     timeout,
     random_seed,
-    duration,
-    excluded_staker_address_for_duration_greater_than_0,
 ):
 
     # Send bad data to assert error return
@@ -285,9 +248,6 @@ def test_bucket_sampling_web_interface(
     if random_seed:
         get_ursulas_params["random_seed"] = random_seed
 
-    if duration:
-        get_ursulas_params["duration"] = duration
-
     #
     # Success
     #
@@ -301,10 +261,6 @@ def test_bucket_sampling_web_interface(
     assert len(set(sampled_ursulas)) == quantity
     for address in exclude_ursulas:
         assert address not in sampled_ursulas
-    if duration and duration > 0:
-        assert (
-            excluded_staker_address_for_duration_greater_than_0 not in sampled_ursulas
-        )
 
     #
     # Test Query parameters
@@ -320,9 +276,6 @@ def test_bucket_sampling_web_interface(
     if random_seed:
         query_params += f"&random_seed={random_seed}"
 
-    if duration:
-        query_params += f"&duration={duration}"
-
     response = porter_web_controller.get(
         "/bucket_sampling", data=json.dumps(get_ursulas_params)
     )
@@ -333,10 +286,6 @@ def test_bucket_sampling_web_interface(
     assert len(set(sampled_ursulas)) == quantity
     for address in exclude_ursulas:
         assert address not in sampled_ursulas
-    if duration and duration > 0:
-        assert (
-            excluded_staker_address_for_duration_greater_than_0 not in sampled_ursulas
-        )
 
     #
     # Failure case: too many ursulas requested

--- a/tests/test_get_ursulas.py
+++ b/tests/test_get_ursulas.py
@@ -43,17 +43,6 @@ def test_get_ursulas_schema(get_random_checksum_address):
 
     # optional components
 
-    # only duration
-    updated_data = dict(required_data)
-    updated_data["duration"] = 0
-    GetUrsulas().load(updated_data)
-
-    updated_data["duration"] = 60 * 60 * 24
-    GetUrsulas().load(updated_data)
-
-    updated_data["duration"] = 60 * 60 * 365
-    GetUrsulas().load(updated_data)
-
     # only exclude
     updated_data = dict(required_data)
     exclude_ursulas = []
@@ -173,20 +162,6 @@ def test_get_ursulas_schema(get_random_checksum_address):
         updated_data["timeout"] = -1
         GetUrsulas().load(updated_data)
 
-    # invalid duration value
-    with pytest.raises(InvalidInputData):
-        updated_data = dict(required_data)
-        updated_data["exclude_ursulas"] = exclude_ursulas
-        updated_data["duration"] = "some number"
-        GetUrsulas().load(updated_data)
-
-    with pytest.raises(InvalidInputData):
-        updated_data = dict(required_data)
-        updated_data["exclude_ursulas"] = exclude_ursulas
-        updated_data["include_ursulas"] = include_ursulas
-        updated_data["duration"] = -1
-        GetUrsulas().load(updated_data)
-
     # invalid min version
     with pytest.raises(InvalidInputData):
         updated_data = dict(required_data)
@@ -221,13 +196,10 @@ def test_get_ursulas_schema(get_random_checksum_address):
 
 
 @pytest.mark.parametrize("timeout", [None, 15, 20])
-@pytest.mark.parametrize("duration", [None, 0, 60 * 60 * 24, 60 * 60 * 24 * 365])
 def test_get_ursulas_python_interface(
     porter,
     ursulas,
     timeout,
-    duration,
-    excluded_staker_address_for_duration_greater_than_0,
 ):
     # simple
     quantity = 4
@@ -236,19 +208,6 @@ def test_get_ursulas_python_interface(
         ursula_info.checksum_address for ursula_info in ursulas_info
     }
     assert len(returned_ursula_addresses) == quantity  # ensure no repeats
-
-    # simple with duration
-    quantity = 4
-    ursulas_info = porter.get_ursulas(quantity=quantity, duration=duration)
-    returned_ursula_addresses = {
-        ursula_info.checksum_address for ursula_info in ursulas_info
-    }
-    assert len(returned_ursula_addresses) == quantity  # ensure no repeats
-    if duration is not None and duration > 0:
-        assert (
-            excluded_staker_address_for_duration_greater_than_0
-            not in returned_ursula_addresses
-        )
 
     ursulas_list = list(ursulas)
 
@@ -324,14 +283,11 @@ def test_get_ursulas_python_interface(
 
 
 @pytest.mark.parametrize("timeout", [None, 10, 20])
-@pytest.mark.parametrize("duration", [None, 0, 60 * 60 * 24, 60 * 60 * 24 * 365])
 def test_get_ursulas_web_interface(
     porter,
     porter_web_controller,
     ursulas,
     timeout,
-    duration,
-    excluded_staker_address_for_duration_greater_than_0,
 ):
     # Send bad data to assert error return
     response = porter_web_controller.get(
@@ -354,14 +310,10 @@ def test_get_ursulas_web_interface(
         "quantity": quantity,
         "include_ursulas": include_ursulas,
         "exclude_ursulas": exclude_ursulas,
-        "duration": 60 * 60 * 24 * 365,
     }
 
     if timeout:
         get_ursulas_params["timeout"] = timeout
-
-    if duration:
-        get_ursulas_params["duration"] = duration
 
     #
     # Success
@@ -381,11 +333,6 @@ def test_get_ursulas_web_interface(
         assert address in returned_ursula_addresses
     for address in exclude_ursulas:
         assert address not in returned_ursula_addresses
-    if duration and duration > 0:
-        assert (
-            excluded_staker_address_for_duration_greater_than_0
-            not in returned_ursula_addresses
-        )
 
     #
     # Test Query parameters
@@ -397,9 +344,6 @@ def test_get_ursulas_web_interface(
     )
     if timeout:
         query_params += f"&timeout={timeout}"
-
-    if duration:
-        query_params += f"&duration={duration}"
 
     response = porter_web_controller.get(query_params)
     assert response.status_code == 200
@@ -413,11 +357,6 @@ def test_get_ursulas_web_interface(
         assert address in returned_ursula_addresses
     for address in exclude_ursulas:
         assert address not in returned_ursula_addresses
-    if duration and duration > 0:
-        assert (
-            excluded_staker_address_for_duration_greater_than_0
-            not in returned_ursula_addresses
-        )
 
     #
     # Failure case: too many ursulas requested


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

Updates Porter based on incompatible changes made to `TACoApplicationChild` contract. `duration` is no longer a parameter when obtaining TACo active stakers.

Related to:
- https://github.com/nucypher/nucypher-contracts/pull/466
- https://github.com/nucypher/nucypher/pull/3726

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR addresses a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
